### PR TITLE
Adding ftdetect 

### DIFF
--- a/ftdetect/avro.vim
+++ b/ftdetect/avro.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.avdl setlocal filetype=avro-idl


### PR DESCRIPTION
When using Pathogen, just placing the plugin under ~/.vimrc/bundle is enough for Avro syntax highlighting.  No need to edit ~/.vimrc!
